### PR TITLE
Use valid and correct KEYWORD_TOKENTYPEs in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
 I2C_EEPROM	KEYWORD1
 write	KEYWORD2
-writeSerial	KEYWORD3
-read	KEYWORD4
-readSerial	KEYWORD4
+writeSerial	KEYWORD2
+read	KEYWORD2
+readSerial	KEYWORD2


### PR DESCRIPTION
Use of the undocumented KEYWORD4 KEYWORD_TOKENTYPE causes the keyword to be colored as an inline comment in Arduino IDE 1.6.4 and older, and as the default coloration used for unrecognized identifiers in newer IDE versions.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype